### PR TITLE
`Bugfix` Too large Results are splitted wrongly (#152)

### DIFF
--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.client/src/edu/kit/kastel/sdq/eclipse/grading/client/mappings/lock/LockResult.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.client/src/edu/kit/kastel/sdq/eclipse/grading/client/mappings/lock/LockResult.java
@@ -2,6 +2,7 @@ package edu.kit.kastel.sdq.eclipse.grading.client.mappings.lock;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,7 +30,7 @@ public class LockResult implements ILockResult {
 				: previousAssessmentresults.get(previousAssessmentresults.size() - 1);
 
 		if (latestResult != null) {
-			this.latestFeedback.addAll(latestResult.getFeedbacks());
+			latestResult.getFeedbacks().stream().filter(Objects::nonNull).forEach(this.latestFeedback::add);
 		}
 	}
 

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationDeserializer.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationDeserializer.java
@@ -42,6 +42,9 @@ public class AnnotationDeserializer {
 	 */
 	public List<IAnnotation> deserialize(List<Feedback> feedbacks) throws IOException {
 		final List<Feedback> matchingFeedbacks = feedbacks.stream().filter(feedback -> {
+			if (feedback == null) {
+				return false;
+			}
 			String text = feedback.getText();
 			return text != null && text.equals(FEEDBACK_TEXT);
 		}).collect(Collectors.toList());

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.core/src/edu/kit/kastel/sdq/eclipse/grading/core/artemis/AnnotationMapper.java
@@ -5,8 +5,10 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -31,6 +33,9 @@ public class AnnotationMapper {
 	// keep this up to date with
 	// https://github.com/ls1intum/Artemis/blob/develop/src/main/java/de/tum/in/www1/artemis/config/Constants.java#L121
 	private static final int FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS = 5000;
+	
+	// amount of space to leave in the feedback-text
+	private static final int FEEDBACK_DETAIL_SAFETY_MARGIN = 50;
 
 	private static final NumberFormat nf = new DecimalFormat("##.###", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
 
@@ -72,6 +77,7 @@ public class AnnotationMapper {
 		final List<Feedback> result = new ArrayList<>(this.getFilteredPreexistentFeedbacks(FeedbackType.AUTOMATIC));
 		result.addAll(submissionIsInvalid ? this.calculateInvalidManualFeedback() : this.calculateManualFeedbacks());
 		result.addAll(this.calculateAnnotationSerialitationAsFeedbacks());
+		result.removeIf(Objects::isNull);
 		return result;
 	}
 
@@ -111,13 +117,10 @@ public class AnnotationMapper {
 	private List<Feedback> calculateManualFeedbacks() {
 		List<Feedback> manualFeedbacks = new ArrayList<>(this.annotations.stream().map(this::createNewManualFeedback).collect(Collectors.toList()));
 		// add the (rated!) rating group annotations
-		manualFeedbacks.addAll( //
-				this.ratingGroups.stream() //
-						.map(this::createNewManualUnreferencedFeedback) //
-						.filter(feedback -> Math.abs(feedback.getCredits()) >= 1E-8) //
-						.collect(Collectors.toList())//
-		);
-
+		this.ratingGroups.forEach(group -> {
+			manualFeedbacks.addAll(this.createNewManualUnreferencedFeedback(group));
+		});
+		
 		return manualFeedbacks;
 	}
 
@@ -141,10 +144,10 @@ public class AnnotationMapper {
 
 	private String calculateResultString(final List<Feedback> allFeedbacks, final double absoluteScore) {
 		final List<Feedback> autoFeedbacks = //
-				allFeedbacks.stream().filter(feedback -> feedback.getFeedbackType() == FeedbackType.AUTOMATIC).collect(Collectors.toList());
+				allFeedbacks.stream().filter(Objects::nonNull).filter(feedback -> feedback.getFeedbackType() == FeedbackType.AUTOMATIC).collect(Collectors.toList());
 
 		final List<Feedback> tests = autoFeedbacks.stream().filter(f -> f.getReference() == null).collect(Collectors.toList());
-		long positiveTests = tests.stream().filter(Feedback::getPositive).count();
+		long positiveTests = tests.stream().filter(feedback -> feedback.getPositive() != null && feedback.getPositive()).count();
 		long numberOfTests = tests.size();
 
 		// ENHANCE We may add "Issues" as text here iff activated ?
@@ -209,18 +212,21 @@ public class AnnotationMapper {
 		return new Feedback(FeedbackType.MANUAL.name(), 0D, null, null, null, text, reference, detailText);
 	}
 
-	private Feedback createNewManualUnreferencedFeedback(IRatingGroup ratingGroup) {
+	private List<Feedback> createNewManualUnreferencedFeedback(IRatingGroup ratingGroup) {
 		final double calculatedPenalty = this.calculatePenaltyForRatingGroup(ratingGroup);
 
-		String detailText = "";
-		detailText += ratingGroup.getDisplayName() + " [" + nf.format(calculatedPenalty);
+		List<String> lines = new ArrayList<>();
+		
+		String annotationHeadline = "";
+		
+		annotationHeadline = ratingGroup.getDisplayName() + " [" + nf.format(calculatedPenalty);
 
 		if (ratingGroup.hasPenaltyLimit()) {
-			detailText += " of at most " + nf.format(-ratingGroup.getPenaltyLimit());
+			annotationHeadline += " of at most " + nf.format(-ratingGroup.getPenaltyLimit());
 		}
 
-		detailText += " points]";
-
+		annotationHeadline += " points]";
+		
 		for (var mistakeType : this.mistakeTypes) {
 			if (!mistakeType.getRatingGroup().equals(ratingGroup)) {
 				continue;
@@ -234,24 +240,50 @@ public class AnnotationMapper {
 			final List<IAnnotation> currentAnnotations = this.annotations.stream() //
 					.filter(annotation -> annotation.getMistakeType().equals(mistakeType)) //
 					.collect(Collectors.toList());
-			detailText += "\n    * \"" + mistakeType.getButtonText() + "\" [" + nf.format(currentPenalty) + "]:";
+			lines.add("\n    * \"" + mistakeType.getButtonText() + "\" [" + nf.format(currentPenalty) + "]:");
 			if (mistakeType.isCustomPenalty()) {
 				for (var annotation : currentAnnotations) {
 					String penalty = nf.format(-annotation.getCustomPenalty().get());
-					detailText += "\n        * " + annotation.getClassFilePath() + " at line " + annotation.getStartLine() + " (" + penalty + "P)";
+					lines.add("\n        * " + annotation.getClassFilePath() + " at line " + annotation.getStartLine() + " (" + penalty + "P)");
 				}
 			} else {
 				for (var annotation : currentAnnotations) {
-					detailText += "\n        * " + annotation.getClassFilePath() + " at line " + annotation.getStartLine();
+					lines.add("\n        * " + annotation.getClassFilePath() + " at line " + annotation.getStartLine());
 				}
 			}
 		}
 
 		if (this.penaltyCalculationStrategy.penaltyLimitIsHitForRatingGroup(ratingGroup)) {
-			detailText += "\n    * Note: The sum of penalties hit the penalty limit for this rating group.";
+			lines.add("\n    * Note: The sum of penalties hit the penalty limit for this rating group.");
 		}
 
-		return new Feedback(FeedbackType.MANUAL_UNREFERENCED.name(), calculatedPenalty, null, null, null, null, null, detailText);
+		
+		List<String> feedbackTexts = new LinkedList<>();
+		
+		if (lines.isEmpty()) {
+			return List.of();
+		}
+		
+		String text = annotationHeadline + " (annotation " + 1 + ")";
+		
+		for (int i = 0; i < lines.size(); i++) {
+			if (text.length() + lines.get(i).length() >= FEEDBACK_DETAIL_TEXT_MAX_CHARACTERS - annotationHeadline.length() - FEEDBACK_DETAIL_SAFETY_MARGIN) {
+				feedbackTexts.add(text);
+				text = annotationHeadline + " (annotation " + (feedbackTexts.size() + 1) + ")";
+			}
+			text += lines.get(i);
+		}
+		feedbackTexts.add(text);
+		
+		List<Feedback> feedbacks = new LinkedList<>();
+		
+		feedbacks.add(new Feedback(FeedbackType.MANUAL_UNREFERENCED.name(), calculatedPenalty, null, null, null, null, null, feedbackTexts.get(0)));
+		
+		for (int i = 1; i < feedbackTexts.size(); i++) {
+			feedbacks.add(new Feedback(FeedbackType.MANUAL_UNREFERENCED.name(), 0d, null, null, null, null, null, feedbackTexts.get(i)));
+		}
+		
+		return feedbacks;
 	}
 
 	private List<Feedback> getFilteredPreexistentFeedbacks(FeedbackType feedbackType) {

--- a/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/observers/ViewAlertObserver.java
+++ b/bundles/edu.kit.kastel.sdq.eclipse.grading.view/src/edu/kit/kastel/eclipse/grading/view/observers/ViewAlertObserver.java
@@ -1,5 +1,7 @@
 package edu.kit.kastel.eclipse.grading.view.observers;
 
+import org.eclipse.core.runtime.ILog;
+import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.dialogs.MessageDialog;
 
 import edu.kit.kastel.eclipse.grading.view.utilities.AssessmentUtilities;
@@ -11,19 +13,24 @@ import edu.kit.kastel.sdq.eclipse.grading.api.controller.IAlertObserver;
  *
  */
 public class ViewAlertObserver implements IAlertObserver {
-
+	
+	private static final ILog log = Platform.getLog(ViewAlertObserver.class); 
+	
 	@Override
-	public void error(String errorMsg, Throwable cause) {
+	public void error(String errorMsg, Throwable cause) {	
+		log.error(errorMsg, cause);
 		MessageDialog.openError(AssessmentUtilities.getWindowsShell(), "Error", errorMsg);
 	}
 
 	@Override
 	public void info(String infoMsg) {
+		log.info(infoMsg);
 		MessageDialog.openInformation(AssessmentUtilities.getWindowsShell(), "Info", infoMsg);
 	}
 
 	@Override
 	public void warn(String warningMsg) {
+		log.warn(warningMsg);
 		MessageDialog.openWarning(AssessmentUtilities.getWindowsShell(), "Warning", warningMsg);
 	}
 


### PR DESCRIPTION
* Removed possible NPTR

* Added proper logging for messages created by ViewAlertObserver

* Added filters for null-feedbacks

* Removed another possible NPTR

* Added logging for the saved assessment-json

* Fixed yet another possible NPTR due to unboxing...

* Finally found and fixed the null-feedbacks

* Code-cleanup